### PR TITLE
retrieve rare name properly when defeating a tracked rare

### DIFF
--- a/WorldQuestTracker_RareFinder.lua
+++ b/WorldQuestTracker_RareFinder.lua
@@ -635,7 +635,7 @@ rf:SetScript ("OnEvent", function (self, event, ...)
 				end
 				
 				--> ask to leave the group
-				if (ff.QuestName2Text.text == alvo_name and IsInGroup()) then
+				if (ff.CurrentQuestName == alvo_name and IsInGroup()) then
 					ff.WorldQuestFinished (0, true)
 				end
 				

--- a/WorldQuestTracker_WorldMap.lua
+++ b/WorldQuestTracker_WorldMap.lua
@@ -1631,9 +1631,7 @@ end
 
 WorldQuestTracker.WorldMapQuestCounter = 0
 
-print(1)
 --questsToUpdate is a hash table with questIDs to just update / if is nil it's a full refresh
-print(2)
 function WorldQuestTracker.UpdateWorldMapSmallIcons (addToWorldMap, questsToUpdate)
 
 	if (not WorldQuestTracker.db.profile.world_map_config.onmap_show) then


### PR DESCRIPTION
Fixes https://www.curseforge.com/wow/addons/world-quest-tracker/issues/1189
Fixes https://www.curseforge.com/wow/addons/world-quest-tracker/issues/1198