### PR TITLE
Fix Forbidden Reach map ID

### DIFF
--- a/WorldQuestTracker_IDs.lua
+++ b/WorldQuestTracker_IDs.lua
@@ -55,7 +55,7 @@ WorldQuestTracker.MapData.ZoneIDs = {
 		THALDRASZUS = 	2025,
 		OHNAHRANPLAINS = 	2023,
 		WAKINGSHORES = 	2022,
-		FORBIDDENREACH =	2026,
+		FORBIDDENREACH =	2151,
 		ZARALEK = 		2133,
 
 	--Shadowlands


### PR DESCRIPTION
Fix displaying forbidden reach WQ on the DF-world map.