### PR TITLE
New Racing filter only works on world map, not zone map

### DIFF
--- a/WorldQuestTracker_ZoneMap.lua
+++ b/WorldQuestTracker_ZoneMap.lua
@@ -850,7 +850,7 @@ function WorldQuestTracker.UpdateZoneWidgets(forceUpdate)
 							WorldQuestTracker.CurrentZoneQuests [questID] = true
 
 							local title, factionID, tagID, tagName, worldQuestType, rarity, isElite, tradeskillLineIndex, tagID, tagName, worldQuestType, rarity, isElite, tradeskillLineIndex, allowDisplayPastCritical, gold, goldFormated, rewardName, rewardTexture, numRewardItems, itemName, itemTexture, itemLevel, itemQuantity, itemQuality, isUsable, itemID, isArtifact, artifactPower, isStackable, stackAmount = WorldQuestTracker.GetOrLoadQuestData(questID, can_cache)
-							local filter, order = WorldQuestTracker.GetQuestFilterTypeAndOrder(worldQuestType, gold, rewardName, itemName, isArtifact, stackAmount, numRewardItems, rewardTexture)
+							local filter, order = WorldQuestTracker.GetQuestFilterTypeAndOrder(worldQuestType, gold, rewardName, itemName, isArtifact, stackAmount, numRewardItems, rewardTexture, tagID)
 							local passFilter = filters [filter]
 
 							if (not passFilter) then


### PR DESCRIPTION
fix issues [#85](https://github.com/Tercioo/World-Quest-Tracker/issues/85)

Make changes to WorldQuestTracker_ZoneMap.lua.

Added 'tagID' parameter to 'WorldQuestTracker.GetQuestFilterTypeAndOrder' function solved the problem.