### PR TITLE
Remove duplicate library from include list

### DIFF
--- a/libs/libs.xml
+++ b/libs/libs.xml
@@ -11,7 +11,6 @@
 	<Include file="AceConfig-3.0\AceConfig-3.0.xml"/>
 	<Include file="AceEvent-3.0\AceEvent-3.0.xml"/>
 	<Include file="AceComm-3.0\AceComm-3.0.xml" />
-	<Include file="AceSerializer-3.0\AceSerializer-3.0.xml" />
 	<Include file="LibSharedMedia-3.0\lib.xml" />
 	<Include file="AceConsole-3.0\AceConsole-3.0.xml"/>
 	<Include file="AceSerializer-3.0\AceSerializer-3.0.xml"/>


### PR DESCRIPTION
Fixes this errror:
```
2x WorldQuestTracker/libs/libs.xml:17 Duplicate File Load Detected. [WorldQuestTracker/libs/AceSerializer-3.0-5/AceSerializer-3.0.xml] first loaded at [WorldQuestTracker/libs/libs.xml:14]
```