### PR TITLE
Fixes taint caused by drawing the travel line on the world map

### DIFF
--- a/WorldQuestTracker_Core.lua
+++ b/WorldQuestTracker_Core.lua
@@ -1368,7 +1368,7 @@ WorldQuestTracker.OnToggleWorldMap = function(self)
 
 			WQTPathFrame:SetScript("OnUpdate", function()
 				--check if the map is opened and if the player is flying
-				if (WorldMapFrame:IsShown() and IsFlying() and not IsInInstance() and WorldQuestTracker.db.profile.path.enabled and GetPlayerFacing()) then
+				if (WorldMapFrame:IsShown() and IsFlying() and not IsInInstance() and WorldQuestTracker.db.profile.path.enabled and GetPlayerFacing() and not InCombatLockdown()) then
 					--get the direction the player is facing
 					local direction = GetPlayerFacing()
 					--build a forward vector based on the the direction the player is facing

--- a/WorldQuestTracker_Core.lua
+++ b/WorldQuestTracker_Core.lua
@@ -246,7 +246,7 @@ WorldQuestTracker.OnToggleWorldMap = function(self)
 
 	if (WorldMapFrame:IsShown()) then
 		--� a primeira vez que � mostrado?
-		if (not WorldMapFrame.hadItsFirstRunAlready) then
+		if (not WorldMapFrame.hadItsFirstRunAlready and not InCombatLockdown()) then
 			local currentMapId = WorldMapFrame.mapID
 
 			if (WorldQuestTracker.DoesMapHasWorldQuests(currentMapId)) then

--- a/WorldQuestTracker_WorldMap.lua
+++ b/WorldQuestTracker_WorldMap.lua
@@ -1307,6 +1307,9 @@ local questLoadFailedAmount = {}
 local worldQuestLockedIndex = 1
 -- ~world -- ~update
 function WorldQuestTracker.UpdateWorldQuestsOnWorldMap(noCache, showFade, isQuestFlaggedRecheck, forceCriteriaAnimation, questList)
+	if InCombatLockdown() then
+		return
+	end
 	if (UnitLevel("player") < 50) then --this has to be improved
 		WorldQuestTracker.HideWorldQuestsOnWorldMap()
 


### PR DESCRIPTION
Addresses #122.

The easiest way to reproduce the original issue and see that this fixes it is to:

1) Mount up on a flying mount
2) Open the world map (click the upper right arrow to make it smaller)
3) Run towards a mob and get in combat
4) Take off and start flying while still in combat
  - Taint error should happen as soon as you take off

Applying the small change in the PR makes it so the error no longer occurs.

**Edit**: I found two additional ways to cause taint, and their fixes:

### The first is if you happen to open the world map for the first time while in combat. 
1) Do a `/reload` - don't open the map yet
2) Enter combat
3) Open the map (preferably in a zone that has WQs)

Without the change in `WorldQuestTracker_Core.lua`, I got a taint every time.

### The next is if you open the map, then right click it to zoom out, all while in combat.

1) Do a `/reload` - open the map to get it in the "safe" state
2) Enter combat
3) Open the map - shouldn't have taint yet
4) Zoom out on the map - taint should happen here