### PR TITLE
Fix WoW 12.0 secret value errors in tooltips

### DIFF
--- a/WorldQuestTracker_ZoneMap.lua
+++ b/WorldQuestTracker_ZoneMap.lua
@@ -101,7 +101,11 @@ function WorldQuestTracker.CreateZoneWidget(index, name, parent, pinTemplate) --
 	button:SetScript("OnEnter", function()
 		if (button.questID and type(button.questID) == "number" and button.questID >= 2) then
 			GameTooltip:SetOwner(button, "ANCHOR_RIGHT")
-			GameTooltip_AddQuest(button)
+			-- Wrap in pcall to avoid taint errors from secret values in 12.0+
+			local ok, err = pcall(GameTooltip_AddQuest, button)
+			if not ok then
+				GameTooltip:AddLine("Quest " .. button.questID)
+			end
 			--TaskPOI_OnEnter(button)
 		end
 	end)


### PR DESCRIPTION
## Summary
- Wrap `GameTooltip_AddQuest` in `pcall` in `WorldQuestTracker_ZoneMap.lua` to prevent taint from secret values propagating through the tooltip system (fixes the `GameTooltip.lua:754` arithmetic error)
- Add `issecretvalue` guards before comparing quest reward values (XP, money, artifact XP, currency counts, item counts) in `WorldQuestTracker_Tracker.lua`
- Wrap `SetTooltipMoney` in `pcall` as defense-in-depth (fixes the `MoneyFrame.lua:292` arithmetic error)

## Context

In WoW 12.0 (Midnight), Blizzard introduced "secret values" - opaque values that cannot be used in arithmetic, string, or comparison operations from addon code. Quest reward APIs like `GetQuestLogRewardMoney()` can now return these secret values, causing errors when the tooltip code tries to compare them with `> 0` or pass them to `SetTooltipMoney`.

## Test plan
- [ ] Hover over world quests on the zone map - tooltip should display without errors
- [ ] Hover over tracked world quests - tooltip should display rewards without errors
- [ ] Verify no BugSack errors from `MoneyFrame.lua` or `GameTooltip.lua` tainted by WorldQuestTracker

Fixes #142, helps with #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)