### PR TITLE
Fix taint in buildTooltip by using SetOwner anchor instead of SetPoint

### DIFF
--- a/WorldQuestTracker_Tracker.lua
+++ b/WorldQuestTracker_Tracker.lua
@@ -558,9 +558,7 @@ end
 
 
 local buildTooltip = function(self)
-	GameTooltip:ClearAllPoints()
-	GameTooltip:SetPoint("TOPRIGHT", self, "TOPLEFT", -20, 0)
-	GameTooltip:SetOwner (self, "ANCHOR_PRESERVE")
+	GameTooltip:SetOwner(self, "ANCHOR_LEFT", -20, 0)
 	local questID = self.questID
 
 	if ( not HaveQuestData (questID) ) then


### PR DESCRIPTION
Fixes #155

`buildTooltip()` was calling `GameTooltip:SetPoint()` from an insecure OnEnter handler, tainting the tooltip's layout values. Replaced with `SetOwner(self, "ANCHOR_LEFT", -20, 0)` which achieves the same positioning through the tooltip API without causing taint.